### PR TITLE
Refactoring and debug target improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,21 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-	"files.exclude": {
-		"out": false // set this to true to hide the "out" folder with the compiled JS files
-	},
-	"search.exclude": {
-		"out": true // set this to false to include "out" folder in search results
-	},
-	"typescript.tsdk": "./node_modules/typescript/lib"
+  "files.exclude": {
+    "out": false // set this to true to hide the "out" folder with the compiled JS files
+  },
+  "search.exclude": {
+    "out": true // set this to false to include "out" folder in search results
+  },
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "swift.targets": [
+    {
+      "name": "Watch",
+      "path": "projects/Watch",
+      "sources": ["Watch/*.swift"],
+      "compilerArguments": [
+        "-sdk",
+        "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk"
+      ]
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,34 @@
 # Changelog
 
+## 2.5.0
+
+- Autocompletion for SPM dependencies #27 (thanks to [@yeswolf](https://github.com/yeswolf))
+- Better support for vscode workspaces
+- New setting `swift.targets` for supporting autocompletion if SDE can't.
+
+Especially when using Xcode projects SDE cannot infer the correct compiler arguments. Now you can fix this by explicitly supplying targets with their sources and compiler arguments. SDE will still detect other targets automatically.
+
+```json
+{
+  "swift.targets": [
+    {
+      "name": "YourWatchExtension",
+      "path": "YourProject/YourWatchExtension",
+      "sources": ["**/*.swift"],
+      "compilerArguments": [
+        "-sdk",
+        "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk",
+        "-target",
+        "armv7k-apple-watchos4.0"
+      ]
+    }
+  ]
+}
+```
+
 ## 2.4.4
 
-- Hotfix release: outdated vscode dependencies #31 (thanks to @akdor1154)
+- Hotfix release: outdated vscode dependencies #31 (thanks to [@akdor1154](https://github.com/akdor1154))
 
 ## 2.4.3
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,38 @@ There aren't too much documents about the development of this project. If you ha
 
 ### How do I get autocompletion for UIKit?
 
-Just add `"sde.sourcekit.compilerOptions": ["-target", "arm64-apple-ios11.0"]` to your workspace settings in Visual Studio Code and restart it.
+You can add new autocomplation targets through your configuration.
+
+```json
+{
+  "swift.targets": [
+    // iOS
+    {
+      "name": "YourApp",
+      "path": "YourApp/YourApp",
+      "sources": ["**/*.swift"],
+      "compilerArguments": [
+        "-sdk",
+        "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk",
+        "-target",
+        "arm64-apple-ios11.0"
+      ]
+    },
+    // WatchOS
+    {
+      "name": "YourApp",
+      "path": "YourApp/YourWatchExtension",
+      "sources": ["**/*.swift"],
+      "compilerArguments": [
+        "-sdk",
+        "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk",
+        "-target",
+        "armv7k-apple-watchos4.0"
+      ]
+    }
+  ]
+}
+```
 
 ### Other questions?
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/vknabel"
   },
   "license": "Apache-2.0",
-  "version": "2.4.4",
+  "version": "2.5.0",
   "publisher": "vknabel",
   "icon": "icons/icon.png",
   "galleryBanner": {
@@ -78,10 +78,49 @@
         },
         "sde.sourcekit.compilerOptions": {
           "type": "array",
-          "description": "Optional compiler options like the target or search paths.",
+          "description": "Optional compiler options like the target or search paths. Will only be used as default. `(debug|release).yaml` builds will override these settings.",
           "default": [],
           "items": {
             "type": "string"
+          }
+        },
+        "swift.targets": {
+          "type": "array",
+          "description": "If SDE cannot reliably detect all targets, you can manually configure them.",
+          "default": [],
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "required": true,
+                "description": "The module name of the target. Will be passed as -module-name."
+              },
+              "path": {
+                "type": "string",
+                "required": true,
+                "description": "The reference path."
+              },
+              "sources": {
+                "required": false,
+                "type": "array",
+                "description": "An array of globs to determine all sources within the current target.",
+                "default": [
+                  "**/*.swift"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "compilerArguments": {
+                "type": "array",
+                "required": false,
+                "description": "Additional compiler arguments to be passed.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
         "sde.enable": {
@@ -174,6 +213,7 @@
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.4",
+    "@types/glob": "^5.0.35",
     "@types/js-yaml": "^3.11.1",
     "@types/node": "^10.1.2",
     "@types/xml-js": "^1.0.0",
@@ -186,6 +226,7 @@
   "dependencies": {
     "bunyan": "^1.8.5",
     "fs-promise": "^1.0.0",
+    "glob": "^7.1.3",
     "js-yaml": "^3.11.0",
     "vscode-debugadapter": "^1.25.0",
     "vscode-debugprotocol": "^1.15.0",

--- a/src/clientMain.ts
+++ b/src/clientMain.ts
@@ -87,7 +87,10 @@ export function activate(context: ExtensionContext) {
     synchronize: {
       configurationSection: ["swift", "editor", "[swift]"],
       // Notify the server about file changes to '.clientrc files contain in the workspace
-      fileEvents: workspace.createFileSystemWatcher("**/*.swift")
+      fileEvents: [
+        workspace.createFileSystemWatcher("**/*.swift"),
+        workspace.createFileSystemWatcher(".build/*.yaml")
+      ]
     },
     initializationOptions: {
       isLSPServerTracingOn: isLSPServerTracingOn,

--- a/src/server/current.ts
+++ b/src/server/current.ts
@@ -23,13 +23,18 @@ export interface Current {
 import * as childProcess from "child_process";
 
 async function spawn(cmd: string) {
+  let buffer = "";
   return new Promise<string>((resolve, reject) => {
     const sp = childProcess.spawn(Current.config.shellPath, ["-c", cmd]);
     sp.stdout.on("data", data => {
-      resolve(data as string);
+      buffer += data;
     });
-    sp.on("exit", error => {
-      reject(error);
+    sp.on("exit", code => {
+      if (code === 0) {
+        resolve(buffer);
+      } else {
+        reject(code);
+      }
     });
   });
 }

--- a/src/server/current.ts
+++ b/src/server/current.ts
@@ -1,0 +1,67 @@
+export interface Current {
+  log(label: string, ...details: any[]);
+  report(label: string, ...details: any[]);
+  spawn(command: string): Promise<string>;
+  swift(inPath: string, command: string): Promise<string>;
+  defaultCompilerArguments: () => string[];
+  config: {
+    isTracingOn: boolean;
+    swiftPath: string;
+    shellPath: string;
+    sourceKitCompilerOptions: string[];
+  };
+}
+
+import * as childProcess from "child_process";
+
+async function spawn(cmd: string) {
+  return new Promise<string>((resolve, reject) => {
+    const sp = childProcess.spawn(Current.config.shellPath, ["-c", cmd]);
+    sp.stdout.on("data", data => {
+      resolve(data as string);
+    });
+    sp.on("error", error => {
+      reject(error);
+    });
+  });
+}
+async function swift(inPath: string, cmd: string) {
+  return await this.spawn(`cd ${inPath} && ${Current.config.swiftPath} ${cmd}`);
+}
+function log(label: string, ...details: any[]) {
+  console.log(`[${label}]`, ...details);
+}
+function report(label: string, ...details: any[]) {
+  console.log(`[ERROR][${label}]`, ...details);
+}
+function defaultCompilerArguments() {
+  return [
+    "-sdk",
+    "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk",
+    "-sdk",
+    "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk",
+    "-sdk",
+    "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk",
+    "-sdk",
+    "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk",
+    "-I",
+    "/System/Library/Frameworks/",
+    "-I",
+    "/usr/lib/swift/pm/",
+    ...Current.config.sourceKitCompilerOptions
+  ];
+}
+
+export let Current: Current = {
+  log,
+  report,
+  spawn,
+  swift,
+  defaultCompilerArguments,
+  config: {
+    isTracingOn: false,
+    swiftPath: "$(which swift)",
+    shellPath: "/bin/bash",
+    sourceKitCompilerOptions: []
+  }
+};

--- a/src/server/package.ts
+++ b/src/server/package.ts
@@ -1,0 +1,10 @@
+export type Path = string;
+
+export type Package = (fromPath: Path) => Promise<Target[]>;
+
+export interface Target {
+  name: string;
+  path: Path;
+  sources: Set<Path>;
+  compilerArguments: string[];
+}

--- a/src/server/packages/available-packages.ts
+++ b/src/server/packages/available-packages.ts
@@ -1,0 +1,46 @@
+import * as path from "path";
+import { descriptionPackage } from "./description-package";
+import { Package, Target } from "../package";
+import { swiftFilePackage } from "./swift-file-package";
+import { debugYamlPackage } from "./debug-yaml-package";
+
+export const availablePackages: Package = async fromPath => {
+  const [
+    debugYamlTargets,
+    descriptionTargets,
+    swiftFileTargets
+  ] = await Promise.all([
+    debugYamlPackage(fromPath),
+    descriptionPackage(fromPath),
+    swiftFilePackage(fromPath)
+  ]);
+  return flatteningTargetsWithUniqueSources(
+    debugYamlTargets,
+    descriptionTargets,
+    swiftFileTargets
+  );
+};
+
+function flatteningTargetsWithUniqueSources(...targets: Target[][]) {
+  return targets.reduce(
+    (current, next) => [...current, ...removingDuplicateSources(next, current)],
+    []
+  );
+}
+
+function removingDuplicateSources(
+  fromTargets: Target[],
+  uniqueTargets: Target[]
+): Target[] {
+  return fromTargets.map(target => {
+    const swiftFilesWithoutTargets = Array.from(target.sources).filter(
+      source =>
+        uniqueTargets.findIndex(desc =>
+          desc.sources.has(
+            path.relative(desc.path, path.resolve(target.path, source))
+          )
+        ) === -1
+    );
+    return { ...target, sources: new Set(swiftFilesWithoutTargets) };
+  });
+}

--- a/src/server/packages/available-packages.ts
+++ b/src/server/packages/available-packages.ts
@@ -3,18 +3,22 @@ import { descriptionPackage } from "./description-package";
 import { Package, Target } from "../package";
 import { swiftFilePackage } from "./swift-file-package";
 import { debugYamlPackage } from "./debug-yaml-package";
+import { configPackage } from "./config-package";
 
 export const availablePackages: Package = async fromPath => {
   const [
+    configTargets,
     debugYamlTargets,
     descriptionTargets,
     swiftFileTargets
   ] = await Promise.all([
+    configPackage(fromPath),
     debugYamlPackage(fromPath),
     descriptionPackage(fromPath),
     swiftFilePackage(fromPath)
   ]);
   return flatteningTargetsWithUniqueSources(
+    configTargets,
     debugYamlTargets,
     descriptionTargets,
     swiftFileTargets

--- a/src/server/packages/config-package.ts
+++ b/src/server/packages/config-package.ts
@@ -1,0 +1,51 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as glob from "glob";
+import { Current } from "../current";
+import { Package } from "../package";
+
+export const configPackage: Package = async fromPath => {
+  const targets = Current.config.targets
+    .filter(
+      ({ path: targetPath }) =>
+        path.isAbsolute(targetPath) ||
+        fs.existsSync(path.resolve(fromPath, targetPath))
+    )
+    .map(async configTarget => {
+      const targetPath = path.normalize(
+        path.resolve(fromPath, configTarget.path)
+      );
+      console.log("targetPath", targetPath);
+      const expandedSources = (configTarget.sources || ["**/*.swift"]).map(
+        expandingSourceGlob(fromPath, targetPath)
+      );
+      const sources = await Promise.all(expandedSources);
+      return {
+        ...configTarget,
+        path: targetPath,
+        sources: new Set([].concat(...sources)),
+        compilerArguments: configTarget.compilerArguments || []
+      };
+    });
+  return await Promise.all(targets);
+};
+
+const expandingSourceGlob = (fromPath: string, targetPath: string) => (
+  sourceGlob: string
+) => {
+  return new Promise<string[]>((resolve, reject) => {
+    const options: glob.IOptions = {
+      cwd: targetPath,
+      root: fromPath
+    };
+    glob(sourceGlob, options, (error, matches) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(
+          matches.map(match => path.normalize(path.resolve(targetPath, match)))
+        );
+      }
+    });
+  });
+};

--- a/src/server/packages/config-package.ts
+++ b/src/server/packages/config-package.ts
@@ -1,8 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as glob from "glob";
 import { Current } from "../current";
 import { Package } from "../package";
+import { expandingSourceGlob } from "../path-helpers";
 
 export const configPackage: Package = async fromPath => {
   const targets = Current.config.targets
@@ -15,7 +15,6 @@ export const configPackage: Package = async fromPath => {
       const targetPath = path.normalize(
         path.resolve(fromPath, configTarget.path)
       );
-      console.log("targetPath", targetPath);
       const expandedSources = (configTarget.sources || ["**/*.swift"]).map(
         expandingSourceGlob(fromPath, targetPath)
       );
@@ -28,24 +27,4 @@ export const configPackage: Package = async fromPath => {
       };
     });
   return await Promise.all(targets);
-};
-
-const expandingSourceGlob = (fromPath: string, targetPath: string) => (
-  sourceGlob: string
-) => {
-  return new Promise<string[]>((resolve, reject) => {
-    const options: glob.IOptions = {
-      cwd: targetPath,
-      root: fromPath
-    };
-    glob(sourceGlob, options, (error, matches) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(
-          matches.map(match => path.normalize(path.resolve(targetPath, match)))
-        );
-      }
-    });
-  });
 };

--- a/src/server/packages/debug-yaml-package.ts
+++ b/src/server/packages/debug-yaml-package.ts
@@ -1,0 +1,92 @@
+import * as fs from "fs";
+import * as yaml from "js-yaml";
+import * as path from "path";
+import { Package, Path, Target } from "../package";
+
+interface DebugYaml {
+  client: {
+    name: "swift-build";
+  };
+  tools: {};
+  targets: { [llTarget: string]: string[] };
+  default: string;
+  commands: {
+    [command: string]: LLCommand;
+  };
+}
+
+interface LLCommand {
+  "module-name": string;
+  sources?: string[];
+  "import-paths"?: string[];
+  "other-args"?: string[];
+}
+
+export const debugYamlPackage: Package = async fromPath => {
+  const debugContents = await contentsOfDebugOrReleaseYaml(fromPath);
+  const debugYaml = yaml.safeLoad(debugContents) as DebugYaml;
+  const targets: Target[] = [];
+  for (const name in debugYaml.commands) {
+    const command = debugYaml.commands[name];
+    if (command.sources == null || command.sources.length === 0) {
+      continue;
+    }
+    targets.push({
+      name: command["module-name"] || name,
+      path: fromPath, // actually a subfolder, but all paths are absolute
+      sources: new Set(
+        command.sources.map(toSource =>
+          path.normalize(path.resolve(fromPath, toSource))
+        )
+      ),
+      compilerArguments: compilerArgumentsForCommand(command)
+    });
+  }
+  console.log(targets);
+  return targets;
+};
+
+function contentsOfFile(file: Path) {
+  return new Promise<string>((resolve, reject) => {
+    fs.readFile(file, "utf8", (error, data) => {
+      if (typeof data === "string") {
+        resolve(data);
+      } else {
+        reject(error);
+      }
+    });
+  });
+}
+
+function compilerArgumentsForCommand(command: LLCommand): string[] {
+  const importPaths = command["import-paths"] || [];
+  const otherArgs = command["other-args"] || [];
+  const moduleNameArgs =
+    (command["module-name"] && [
+      "-module-name",
+      command["module-name"],
+      "-Onone"
+    ]) ||
+    [];
+  const importPathArgs = importPaths.map(importPath => [
+    "-Xcc",
+    "-I",
+    "-Xcc",
+    importPath,
+    "-I",
+    importPath,
+    "-Xcc",
+    "-F",
+    "-Xcc",
+    importPath,
+    "-F",
+    importPath
+  ]);
+  return otherArgs.concat(moduleNameArgs, ...importPathArgs);
+}
+
+function contentsOfDebugOrReleaseYaml(fromPath: Path) {
+  return contentsOfFile(path.resolve(fromPath, ".build", "debug.yaml")).catch(
+    () => contentsOfFile(path.resolve(fromPath, ".build", "release.yaml"))
+  );
+}

--- a/src/server/packages/debug-yaml-package.ts
+++ b/src/server/packages/debug-yaml-package.ts
@@ -23,7 +23,12 @@ interface LLCommand {
 }
 
 export const debugYamlPackage: Package = async fromPath => {
-  const debugContents = await contentsOfDebugOrReleaseYaml(fromPath);
+  let debugContents: string;
+  try {
+    debugContents = await contentsOfDebugOrReleaseYaml(fromPath);
+  } catch (error) {
+    return [];
+  }
   const debugYaml = yaml.safeLoad(debugContents) as DebugYaml;
   const targets: Target[] = [];
   for (const name in debugYaml.commands) {
@@ -42,7 +47,6 @@ export const debugYamlPackage: Package = async fromPath => {
       compilerArguments: compilerArgumentsForCommand(command)
     });
   }
-  console.log(targets);
   return targets;
 };
 

--- a/src/server/packages/debug-yaml-package.ts
+++ b/src/server/packages/debug-yaml-package.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as yaml from "js-yaml";
 import * as path from "path";
 import { Package, Path, Target } from "../package";
+import { compilerArgumentsForImportPath } from "../path-helpers";
 
 interface DebugYaml {
   client: {
@@ -72,20 +73,7 @@ function compilerArgumentsForCommand(command: LLCommand): string[] {
       "-Onone"
     ]) ||
     [];
-  const importPathArgs = importPaths.map(importPath => [
-    "-Xcc",
-    "-I",
-    "-Xcc",
-    importPath,
-    "-I",
-    importPath,
-    "-Xcc",
-    "-F",
-    "-Xcc",
-    importPath,
-    "-F",
-    importPath
-  ]);
+  const importPathArgs = importPaths.map(compilerArgumentsForImportPath);
   return otherArgs.concat(moduleNameArgs, ...importPathArgs);
 }
 

--- a/src/server/packages/description-package.ts
+++ b/src/server/packages/description-package.ts
@@ -1,0 +1,41 @@
+import * as path from "path";
+import { Current } from "../current";
+import { Package, Target, Path } from "../package";
+const joinPath = path.join;
+
+type PackageDescription =
+  | { targets: TargetDescription[]; modules: undefined }
+  | { targets: undefined; modules: TargetDescription[] };
+interface TargetDescription {
+  name: string;
+  path: string;
+  sources: string[];
+}
+
+export const descriptionPackage: Package = async fromPath => {
+  try {
+    const data = await Current.swift(fromPath, `package describe --type json`);
+    const packageDescription = JSON.parse(data) as PackageDescription;
+    const targetDescription =
+      packageDescription.modules || packageDescription.targets;
+    return targetDescription.map(targetFromDescriptionFromPath(fromPath));
+  } catch (error) {
+    Current.report(error);
+    return [];
+  }
+};
+
+function targetFromDescriptionFromPath(fromPath: Path) {
+  return ({ name, path, sources }: TargetDescription): Target => {
+    return {
+      name,
+      path,
+      sources: new Set(sources),
+      compilerArguments: [
+        "-I",
+        joinPath(fromPath, ".build", "debug"),
+        ...Current.defaultCompilerArguments()
+      ]
+    };
+  };
+}

--- a/src/server/packages/swift-file-package.ts
+++ b/src/server/packages/swift-file-package.ts
@@ -1,0 +1,37 @@
+import * as fs from "fs";
+import * as path from "path";
+import { Package, Path } from "../package";
+
+export const swiftFilePackage: Package = async fromPath => {
+  return [
+    {
+      name: path.basename(fromPath),
+      path: fromPath,
+      sources: new Set(
+        allSwiftFilesInPath(fromPath).map(file =>
+          path.normalize(path.resolve(fromPath, file))
+        )
+      ),
+      compilerArguments: []
+    }
+  ];
+};
+
+function allSwiftFilesInPath(root: Path): Path[] {
+  const result = new Array<string>();
+  try {
+    const dir = fs
+      .readdirSync(root)
+      .filter(sub => !sub.startsWith(".") && sub !== "Carthage");
+    for (const sub of dir) {
+      if (path.extname(sub) === ".swift") {
+        result.push(path.join(root, sub));
+      } else {
+        result.push(...allSwiftFilesInPath(path.join(root, sub)));
+      }
+    }
+    return result;
+  } catch (error) {
+    return result;
+  }
+}

--- a/src/server/path-helpers.ts
+++ b/src/server/path-helpers.ts
@@ -1,0 +1,37 @@
+import * as path from "path";
+import * as glob from "glob";
+
+export const expandingSourceGlob = (fromPath: string, targetPath: string) => (
+  sourceGlob: string
+) => {
+  return new Promise<string[]>((resolve, reject) => {
+    const options: glob.IOptions = {
+      cwd: targetPath,
+      root: fromPath
+    };
+    glob(sourceGlob, options, (error, matches) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(
+          matches.map(match => path.normalize(path.resolve(targetPath, match)))
+        );
+      }
+    });
+  });
+};
+
+export const compilerArgumentsForImportPath = (importPath: string) => [
+  "-Xcc",
+  "-I",
+  "-Xcc",
+  importPath,
+  "-I",
+  importPath,
+  "-Xcc",
+  "-F",
+  "-Xcc",
+  importPath,
+  "-F",
+  importPath
+];

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -24,6 +24,9 @@ import * as fs from "fs";
 import * as sourcekitProtocol from "./sourcekites";
 import * as childProcess from "child_process";
 import { parseDocumentation } from "./sourcekit-xml";
+import { Target } from "./package";
+import { availablePackages } from "./packages/available-packages";
+import { Current } from "./current";
 export const spawn = childProcess.spawn;
 
 // Create a connection for the server. The connection uses Node's IPC as a transport
@@ -39,109 +42,37 @@ let documents: TextDocuments = new TextDocuments();
 // for open, change and close text document events
 documents.listen(connection);
 
-let allModulePaths: Map<string | null, string>;
-let allModuleSources: Map<string | null, Set<string>>;
-export function initializeModuleMeta() {
-  trace("***initializeModuleMeta***");
-  allModulePaths = new Map([[null, workspaceRoot]]);
-  allModuleSources = new Map([[null, new Set()]]);
-  const shPath = getShellExecPath();
-  trace("***getShellExecPath: ", shPath);
-  const sp = spawn(shPath, [
-    "-c",
-    `cd ${workspaceRoot} && ${swiftDiverBinPath} package describe --type json`
-  ]);
-  sp.stdout.on("data", data => {
-    if (isTracingOn) {
-      trace("***swift package describe stdout*** ", "" + data);
-    }
-    //TODO more here
-    const pkgDesc = JSON.parse(data as string);
-    for (const m of <Object[]>pkgDesc["modules"] || pkgDesc["targets"]) {
-      const mn = m["name"];
-      const mp = m["path"];
-      const ss = <string[]>m["sources"];
-      const set = new Set();
-      ss.forEach(f => set.add(path.join(mp, f)));
-      allModuleSources.set(mn, set);
-      allModulePaths.set(mn, mp);
-    }
-  });
-  sp.stderr.on("data", data => {
-    trace("***swift package describe stderr*** ", "" + data);
-    const globalSources = allModuleSources.get(null);
-    gatherAllSwiftFilesInPath(workspaceRoot).forEach(
-      globalSources.add.bind(globalSources)
-    );
-  });
-
-  sp.on("error", function(err) {
-    trace("***swift package describe error*** ", (<Error>err).message);
-    if ((<Error>err).message.indexOf("ENOENT") > 0) {
-      const msg =
-        "The '" +
-        swiftDiverBinPath +
-        "' command is not available." +
-        " Please check your swift executable user setting and ensure it is installed.";
-      trace("***swift executable not found***", msg);
-    }
-    throw err; //FIXME more friendly prompt
-  });
+let targets: Target[] | null;
+export async function initializeModuleMeta() {
+  targets = await availablePackages(workspaceRoot);
 }
 
-function gatherAllSwiftFilesInPath(root: string): string[] {
-  const result = new Array<string>();
-  try {
-    const dir = fs
-      .readdirSync(root)
-      .filter(sub => !sub.startsWith(".") && sub !== "Carthage");
-    for (const sub of dir) {
-      if (path.extname(sub) === ".swift") {
-        result.push(path.join(root, sub));
-      } else {
-        result.push(...gatherAllSwiftFilesInPath(path.join(root, sub)));
-      }
+export function targetForSource(srcPath: string): Target {
+  return (
+    (targets &&
+      targets.find(target => target.sources.has(path.normalize(srcPath)))) || {
+      name: path.basename(srcPath),
+      path: srcPath,
+      sources: new Set([srcPath]),
+      compilerArguments: []
     }
-    return result;
-  } catch (error) {
-    return result;
-  }
-}
-
-export function getAllSourcePaths(srcPath: string): string[] {
-  const sp = path.dirname(srcPath);
-  for (let [moduleName, modulePath] of allModulePaths) {
-    if (
-      moduleName != null &&
-      path.normalize(sp).includes(path.normalize(modulePath))
-    ) {
-      let ss = allModuleSources.get(moduleName);
-      // trace("**getAllDocumentPaths** ", Array.from(ss).join(","))
-      return Array.from(ss);
-    }
-  }
-  // when not found: interpret all global files
-  const globalSources = allModuleSources.get(null);
-  if (globalSources.has(srcPath) === false) {
-    globalSources.add(srcPath);
-  }
-  return Array.from(allModuleSources.get(null));
+  );
 }
 
 // After the server has started the client sends an initilize request. The server receives
 // in the passed params the rootPath of the workspace plus the client capabilites.
 export let workspaceRoot: string;
-export let isTracingOn: boolean;
 connection.onInitialize(
   (params: InitializeParams, cancellationToken): InitializeResult => {
-    isTracingOn = params.initializationOptions.isLSPServerTracingOn;
+    Current.config.isTracingOn =
+      params.initializationOptions.isLSPServerTracingOn;
     skProtocolPath = params.initializationOptions.skProtocolProcess;
     skProtocolProcessAsShellCmd =
       params.initializationOptions.skProtocolProcessAsShellCmd;
     skCompilerOptions = params.initializationOptions.skCompilerOptions;
     trace(
       "-->onInitialize ",
-      `isTracingOn=[${isTracingOn}],
+      `isTracingOn=[${Current.config.isTracingOn}],
 	skProtocolProcess=[${skProtocolPath}],skProtocolProcessAsShellCmd=[${skProtocolProcessAsShellCmd}]`
     );
     workspaceRoot = params.rootPath;
@@ -212,7 +143,7 @@ connection.onDidChangeConfiguration(change => {
 
   //FIXME reconfigure when configs haved
   sourcekitProtocol.initializeSourcekite();
-  if (!allModuleSources) {
+  if (!targets) {
     //FIXME oneshot?
     initializeModuleMeta();
   }
@@ -255,23 +186,14 @@ connection.onDidChangeWatchedFiles(watched => {
   // trace('---','onDidChangeWatchedFiles');
   watched.changes.forEach(e => {
     let file: string;
-    function targetEntryForFile(filePath: string): [string | null, string] {
-      return (
-        Array.from(allModulePaths.entries()).find(([targetName]) =>
-          file.startsWith(targetName)
-        ) || [null, allModulePaths.get(null)]
-      );
-    }
     switch (e.type) {
       case FileChangeType.Created:
         file = fromUriString(e.uri);
-        const [targetNameToAdd] = targetEntryForFile(file);
-        allModuleSources.get(targetNameToAdd).add(file);
+        targetForSource(file).sources.add(file);
         break;
       case FileChangeType.Deleted:
         file = fromUriString(e.uri);
-        const [targetNameToDelete] = targetEntryForFile(file);
-        allModuleSources.get(targetNameToDelete).delete(file);
+        targetForSource(file).sources.delete(file);
         break;
       default:
       //do nothing
@@ -621,49 +543,9 @@ function decode(str) {
 export function getShellExecPath() {
   return fs.existsSync(shellPath) ? shellPath : "/usr/bin/sh";
 }
-/**
- * NOTE:
- * now the SDE only support the convention based build
- *
- * TODO: to use build yaml?
- */
-let argsImportPaths: string[] = null;
-export function loadArgsImportPaths(): string[] {
-  if (!argsImportPaths) {
-    argsImportPaths = [];
-    argsImportPaths.push("-I");
-    argsImportPaths.push(path.join(workspaceRoot, ".build", "debug"));
-    //FIXME system paths can not be available automatically?
-    // rt += " -I"+"/usr/lib/swift/linux/x86_64"
-    argsImportPaths.push("-sdk");
-    argsImportPaths.push(
-      "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
-    );
-    argsImportPaths.push("-sdk");
-    argsImportPaths.push(
-      "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
-    );
-    argsImportPaths.push("-sdk");
-    argsImportPaths.push(
-      "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk"
-    );
-    argsImportPaths.push("-sdk");
-    argsImportPaths.push(
-      "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk"
-    );
-    argsImportPaths.push("-I");
-    argsImportPaths.push("/System/Library/Frameworks/");
-    argsImportPaths.push("-I");
-    argsImportPaths.push("/usr/lib/swift/pm/");
-    argsImportPaths.push(...skCompilerOptions);
-    return argsImportPaths;
-  } else {
-    return argsImportPaths;
-  }
-}
 
 export function trace(prefix: string, msg?: string) {
-  if (isTracingOn) {
+  if (Current.config.isTracingOn) {
     if (msg) {
       connection.console.log(prefix + msg);
     } else {

--- a/src/server/sourcekites.ts
+++ b/src/server/sourcekites.ts
@@ -112,7 +112,7 @@ class SourcekiteResponseHandler {
   private handleResponse(data): void {
     this.output += data;
     if (Current.config.isTracingOn) {
-      Current.log("SourcekiteResponseHandler", data);
+      Current.log("SourcekiteResponseHandler", `${data}`);
     }
     if (this.output.endsWith("}\n\n")) {
       const idx = this.output.indexOf("\n");

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,9 +13,21 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
 
+"@types/glob@^5.0.35":
+  version "5.0.35"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.35.tgz#1ae151c802cece940443b5ac246925c85189f32a"
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/js-yaml@^3.11.1":
   version "3.11.1"
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.11.1.tgz#ac5bab26be5f9c6f74b6b23420f2cfa5a7a6ba40"
+
+"@types/minimatch@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
 
 "@types/node@*", "@types/node@^10.1.2":
   version "10.3.0"
@@ -546,6 +558,17 @@ glob@^6.0.1:
     inflight "^1.0.4"
     inherits "2"
     minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 


### PR DESCRIPTION
This PR implements changes proposed in https://github.com/vknabel/vscode-swift-development-environment/issues/27#issuecomment-414717260.

First of all, it includes some major refactoring

* Introduces `Current` type
* Avoid uses of `rootPath` in favor of `workspaceFolders` for better workspace support
* Replaces `allModulePaths` and `allModuleSources` with `targets`
* Extracted different behaviors that wrote into `allModulePaths` and `allModuleSources` into `Package`s

Within this PR, a `Package` provide autocompletion `Target`s (`module` is a keyword in JS).

The following packages are known:
* `availablePackages` which includes all other packages. No new behavior.
* `configPackage` providing targets from `swift.targets` setting. New behavior.
* `debugYamlPackage` provides targets by reading the `.build/(debug|release).yaml` files. New behavior as proposed by https://github.com/vknabel/vscode-swift-development-environment/issues/27#issuecomment-414717260.
* `description-package` provides the old behavior of SDE as fallback if `debugYamlPackage` is not available using `swift package describe --type json`. No new behavior.
* `swift-file-package` provides a helper target containing all unused Swift files. No new behavior.
