### PR TITLE
resolve -XSwiftc flag error

### DIFF
--- a/src/SwiftTools.ts
+++ b/src/SwiftTools.ts
@@ -20,7 +20,7 @@ export function buildPackage(
   stdout = "";
   stderr = "";
   error = null;
-  const sb = cp.spawn(swiftBinPath, params, { cwd: pkgPath });
+  const sb = cp.spawn(swiftBinPath, params, { cwd: pkgPath, shell: true });
   sb.stdout.on("data", data => {
     stdout += data;
     dumpInConsole("" + data);


### PR DESCRIPTION
`-XSwiftc` will take double quote as the part of argument, but nodejs needs `shell: true` to support it (https://github.com/nodejs/node/issues/10461)

my `settings.json` needs to pass `-target` to swift compiler by
```
    "sde.swiftBuildingParams" : [
        "build",
        "-Xswiftc",
        "\"-target\"",
        "-Xswiftc",
        "\"x86_64-apple-ios12.1-simulator\"",
        "-Xswiftc",
        "\"-sdk\"",
        "-Xswiftc",
        "\"/Applications/Xcode-beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator13.0.sdk\""
     ]
```
The double quote`\"` is not correctly handled without `shell: true`
close #55