### PR TITLE
support ios for Sourcekit-lsp

### DIFF
--- a/src/clientMain.ts
+++ b/src/clientMain.ts
@@ -100,11 +100,17 @@ function currentServerOptions(context: ExtensionContext) {
     const toolchain = workspace
       .getConfiguration("sourcekit-lsp")
       .get<string>("toolchainPath");
+
+    // sourcekit-lsp takes -Xswiftc arguments like "swift build", but it doesn't need "build" argument
+    let sourceKitArgs = (<string[]>(
+      workspace.getConfiguration().get("sde.swiftBuildingParams")
+    ) || []).filter(param => param !== "build")
+
     const env: NodeJS.ProcessEnv = toolchain
       ? { ...process.env, SOURCEKIT_TOOLCHAIN_PATH: toolchain }
       : process.env;
 
-    const run: Executable = { command: executableCommand, options: { env } };
+    const run: Executable = { command: executableCommand, options: { env }, args: sourceKitArgs};
     const serverOptions: ServerOptions = run;
     return serverOptions;
   }


### PR DESCRIPTION
`sourcekit-lsp` needs additional arguments to find iOS SDK
the arguments are the same as `swift build`, so I pass these arguments to `sourcekit-lsp` as well

example setting:
![截圖 2020-03-09 下午6 32 45](https://user-images.githubusercontent.com/4080524/76205270-db94b980-6234-11ea-9a4e-45d2ddcca4b3.jpg)

```
    "sde.swiftBuildingParams" : [
        "build",
        "-Xswiftc",
        "-sdk",
        "-Xswiftc",
        "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
        "-Xswiftc",
        "-target",
        "-Xswiftc",
        "x86_64-apple-ios12.1-simulator"
    ],
```

To test this feature, please follow the instruction under the section 
`Create a Swift Package` in https://funnyitworkedlasttime.dev/posts/2020-01-10-swift-vscode-sourcekit-lsp/
