### PR TITLE
update readme for easier iOS devilment setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,8 @@ You can add the following configs. This will improve your autocompletion. Though
 
 ### How do I get autocompletion for UIKit?
 
-You can add new autocomplation targets through your configuration.
+With sourcekite, you can add new autocompletion targets through your configuration.
 
-Using sourcekite
 ```json
 // .vscode/settings.json example for iOS and WatchOS
 {

--- a/README.md
+++ b/README.md
@@ -121,6 +121,48 @@ You can add new autocomplation targets through your configuration.
 }
 ```
 
+After Xcode 11.4, you may use its built-in support for sourcekit-lsp
+```json
+// .vscode/settings.json example for iOS
+{
+    "sde.languageservermode": "sourcekit-lsp",
+    "sourcekit-lsp.serverPath": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp",
+    "sourcekit-lsp.toolchainPath": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain",
+    "sde.swiftBuildingParams" : [
+        "build",
+        "-Xswiftc",
+        "-sdk",
+        "-Xswiftc",
+        "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk",
+        "-Xswiftc",
+        "-target",
+        "-Xswiftc",
+        "arm64-apple-ios11.0"
+    ]
+}
+```
+
+```json
+// .vscode/settings.json example for WatchOS
+{
+    "sde.languageservermode": "sourcekit-lsp",
+    "sourcekit-lsp.serverPath": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp",
+    "sourcekit-lsp.toolchainPath": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain",
+    "sde.swiftBuildingParams" : [
+        "build",
+        "-Xswiftc",
+        "-sdk",
+        "-Xswiftc",
+        "/Applications/Xcode.app/Contents/Developer/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk",
+        "-Xswiftc",
+        "-target",
+        "-Xswiftc",
+        "armv7k-apple-watchos4.0"
+    ]
+}
+```
+
+
 ### Other questions?
 
 If so, file an [issue](https://github.com/vknabel/swift-development-environment/issues), please :)

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ With sourcekite, you can add new autocompletion targets through your configurati
 }
 ```
 
-After Xcode 11.4, you may use its built-in support for sourcekit-lsp
+Since Xcode 11.4, you may use its built-in support for sourcekit-lsp
 ```json
 // .vscode/settings.json example for iOS
 {

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ You can add the following configs. This will improve your autocompletion. Though
 
 You can add new autocomplation targets through your configuration.
 
+Using sourcekite
 ```json
 // .vscode/settings.json example for iOS and WatchOS
 {


### PR DESCRIPTION
sorry for the late reply. 
I think the readme should be updated as well. 

As a pure iOS dev, I don't really need the per-project setting. Single global settings is good enough.
The current readme is really scary for the new users (like the guy who wrote https://funnyitworkedlasttime.dev/posts/2020-01-10-swift-vscode-sourcekit-lsp/)

Besides, the original example only works for `sourcekite`. The `sourcekit-lsp` implementation doesn't read `swift.targets.compilerArguments`. 

At this moment, it's not possible for `sourcekit-lsp` to support iOS and WatchOS in the same project unless `swift.targets.compilerArguments` is handled correctly.  It's not an easy task because we will need to activate two `sourcekit-lsp` servers with different SDK settings (iOS and WatchOS) at the same time. 

Anyway, thank you for your great extension :)