### PR TITLE
Update instructions for sourcekit-lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ If you experience any problems during installation, file an issue. All kind of f
 ### Using sourcekit-lsp
 
 1. Install [SDE](https://marketplace.visualstudio.com/items?itemName=vknabel.vscode-swift-development-environment).
-2. [Install sourcekit-lsp](https://github.com/apple/sourcekit-lsp#building-sourcekit-lsp).
-3. Add the _absolute_ path to your compiled sourcekite binary `sourcekit-lsp.serverPath`, optionally to your toolchain `sourcekit-lsp.toolchainPath` and tell SDE to use sourcekit-lsp `"sde.languageServerMode": "sourcekit-lsp"`.
+2. Recent versions of Xcode ship with `sourcekit-lsp`, you can check its path running `xcrun -f sourcekit-lsp`. If not found, please [install sourcekit-lsp](https://github.com/apple/sourcekit-lsp#building-sourcekit-lsp).
+3. Set `"swift.languageServerPath": "absolute path to the sourcekit-lsp executable"` and `"sde.languageServerMode": "sourcekit-lsp"`.
 
 ### Using Langserver Swift
 


### PR DESCRIPTION
I had to Google around to find these simple couple of settings work for modern installations. I am just learning Swift, not sure about the deletion of the tool chain bit. In any case, you do not need that `SourceKit-LS` extension anymore, right?