### PR TITLE
Fix case of languageServerMode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Since Xcode 11.4, you may use its built-in support for sourcekit-lsp
 ```json
 // .vscode/settings.json example for iOS
 {
-  "sde.languageservermode": "sourcekit-lsp",
+  "sde.languageServerMode": "sourcekit-lsp",
   "sourcekit-lsp.serverPath": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp",
   "sourcekit-lsp.toolchainPath": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain",
   "sde.swiftBuildingParams": [
@@ -152,7 +152,7 @@ Since Xcode 11.4, you may use its built-in support for sourcekit-lsp
 ```json
 // .vscode/settings.json example for WatchOS
 {
-  "sde.languageservermode": "sourcekit-lsp",
+  "sde.languageServerMode": "sourcekit-lsp",
   "sourcekit-lsp.serverPath": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp",
   "sourcekit-lsp.toolchainPath": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain",
   "sde.swiftBuildingParams": [


### PR DESCRIPTION
Issue #74 revealed that keys are case sensitive and if you copy and paste the example with the lower case languageservermode you will see an error.